### PR TITLE
Allow vim gj plugin to use even opening file in project subfolder

### DIFF
--- a/bin/gj
+++ b/bin/gj
@@ -140,6 +140,9 @@ def main():
                       help=('Used for multiple pattern search. By default all patterns are searched'
                             ' in the same line. With this flag, use the first pattern to fine target line'
                             ' and search the rest patterns in the +/- N lines (default: 0).'))
+    parser.add_option('--db', dest='db_path',
+                      type='string', default='ID',
+                      help='Specify text index database path')
     options, args = parser.parse_args()
 
     if options.config:
@@ -174,7 +177,7 @@ def main():
         if index_source:
             print('> Index source codes ...')
             print('')
-            result = gj_util.build_index()
+            result = gj_util.build_index(options.db_path)
 
         filename = gj_util.CONFIG_FILE
         if os.path.exists(filename):
@@ -205,8 +208,8 @@ def main():
         parser.print_help()
         return 2
 
-    if not options.definition and not os.path.exists('ID'):
-        print('Database file "ID" is not found. Have you run "gj -i"?')
+    if not options.definition and not os.path.exists(options.db_path):
+        print('Database file "%s" is not found. Have you run "gj -i"?' % options.db_path)
         return 3
 
     patterns = process_args(args)
@@ -214,6 +217,7 @@ def main():
     # Set config.
     gj_util.config['verbose'] = options.verbose
     gj_util.config['search_extended_lines'] = options.extended
+    gj_util.config['db_path'] = options.db_path
 
     # Find matched symbols
     if options.symbol:

--- a/bin/gj_symbol
+++ b/bin/gj_symbol
@@ -36,20 +36,24 @@ def main():
     parser.add_option('-p', '--path', dest='path',
                       type='string', default='',
                       help='Search symbols under specific path. This also applies --verbose')
+    parser.add_option('--db', dest='db_path',
+                      type='string', default='ID',
+                      help='Specify text index database path')
     options, args = parser.parse_args()
 
     if len(args) != 1:
         parser.print_help()
         return 2
 
-    if not os.path.exists('ID'):
-        print 'Database file "ID" is not found. Have you run "gj -i"?'
+    if not os.path.exists(options.db_path):
+        print('Database file "%s" is not found. Have you run "gj -i"?' % options.db_path)
         return 3
 
     pattern, = args
 
     # Find matched symbols
     gj_util.config['verbose'] = options.verbose
+    gj_util.config['db_path'] = options.db_path
     lines = gj_util.find_symbols(pattern,
                                  path_pattern=options.path)
     for line in lines:

--- a/bin/gj_util.py
+++ b/bin/gj_util.py
@@ -39,6 +39,7 @@ DEBUG = False
 config = {
     'search_extended_lines': 0,
     'verbose': False,
+    'db_path': 'ID',
 }
 
 #-----------------------------------------------------------
@@ -135,9 +136,9 @@ def check_install():
             print(msg)
             sys.exit(1)
 
-def build_index():
-    path = os.path.join(os.path.dirname(__file__), LANG_MAP_FILE)
-    return _mkid(path)
+def build_index(db_path):
+    lang_path = os.path.join(os.path.dirname(__file__), LANG_MAP_FILE)
+    return _mkid(lang_path, db_path)
 
 
 def _find_matches(pattern):
@@ -385,8 +386,8 @@ def find_symbols(pattern, path_pattern=''):
 #-----------------------------------------------------------
 # private
 #-----------------------------------------------------------
-def _mkid(lang_file):
-    cmd = ['mkid', '-m', lang_file]
+def _mkid(lang_file, db_path):
+    cmd = ['mkid', '-m', lang_file, '-f', db_path]
     process = subprocess.Popen(cmd,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
@@ -449,17 +450,21 @@ def _execute(args):
     return text.split('\n')
 
 def _gid(pattern):
+    global config
+
     # Support searching "FUNCTION(" or "FUNCTION()".
     # () has special meaning for gid. Do not pass it to gid.
     if pattern.endswith('('):
         pattern = pattern[:-1]
     elif pattern.endswith('()'):
         pattern = pattern[:-2]
-    cmd = [_get_gid_cmd(), pattern]
+    cmd = [_get_gid_cmd(), '-f', config['db_path'], pattern]
     return _execute(cmd)
 
 def _lid(pattern, args):
-    cmd = ['lid'] + args + [pattern]
+    global config
+
+    cmd = ['lid', '-f', config['db_path']] + args + [pattern]
     return _execute(cmd)
 
 def _highlight(pattern, text, level=2):

--- a/plugin/gj.vim
+++ b/plugin/gj.vim
@@ -12,7 +12,24 @@ if (exists('g:loaded_gj_vim') && g:loaded_gj_vim)
 endif
 let g:loaded_gj_vim = 1
 
-let g:gjprg = expand("<sfile>:p:h") . "/../bin/gj_without_interaction"
+let g:gjprg = get(g:, "gj#gj_path", expand("<sfile>:p:h") . "/../bin/gj_without_interaction")
+let g:gj_db_name = get(g:, "gj#db_name", "ID")
+
+function! s:FindDbPath(db_name) abort
+  let curr_dir = expand("%:p:h")
+  if !filereadable(expand("%:p"))
+      let curr_dir = expand("%:p")
+  endif
+  let db_path = curr_dir . "/" . a:db_name
+  while curr_dir != "/"
+    let db_path = curr_dir . "/" . a:db_name
+    if filereadable(db_path)
+        return db_path
+    endif
+    let curr_dir = fnamemodify(curr_dir, ":h")
+  endwhile
+  return a:db_name
+endfunction
 
 function! s:Gj(cmd, args)
   redraw
@@ -24,7 +41,8 @@ function! s:Gj(cmd, args)
   try
     let &grepprg=g:gjprg
     let &grepformat="%f:%l:%c:%m"
-    silent execute a:cmd . " " . escape(l:grepargs, '|')
+    let db_path = s:FindDbPath(g:gj_db_name)
+    silent execute a:cmd . " --db " . escape(db_path, '|') . " " . escape(l:grepargs, '|')
   finally
     let &grepprg=grepprg_bak
     let &grepformat=grepformat_bak


### PR DESCRIPTION
See the project folder structure:
```
/project/
├── ID
└── /subfolder/
    └── foo.cpp
```
If I use `cd /project/subfolder && vim foo.cpp`, the gj vim plugin cannot locate idutils DB correctly.
This PR is just to fulfill this use case.

In summary, there are two major changes:
1. Add `--db` option to gj, allowing idutils to use custom DB path instead of ./ID
2. For vim plugin, try to find idutils DB from current opening file's ancestor folders.